### PR TITLE
updating readme with new executable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ For the above example, the command used was `./intensify.sh heart.png heart-inte
 ## Requirements
 
 - 'imagemagick' is installed and available in the PATH (on a mac, use 'brew install imagemagick')
+
+## Update
+
+If you download a newer version of ImageMagick, you will likely encounter "Invalid Parameter" issues. This is because the executable is now called `magick.exe` and not `convert.exe`. If you update the command in the shell script locally, this will work without issue.


### PR DESCRIPTION
turns out the executable is named differently in newer versions. on windows machines, anyway, a different convert.exe tries to execute the commands. you get "invalid parameter" errors.